### PR TITLE
Deprecated numpy function and consistent IQ data

### DIFF
--- a/spectrum_painter/img2iqstream.py
+++ b/spectrum_painter/img2iqstream.py
@@ -19,7 +19,7 @@ def img2iqstream(samplerate, linetime, output, format, srcs):
     for src in srcs:
         iq_samples = painter.convert_image(src)
         target_format = formatter.convert(iq_samples)
-        output.write(target_format.tostring())
+        output.write(target_format.tobytes())
 
 
 if __name__ == '__main__':

--- a/spectrum_painter/spectrum_painter.py
+++ b/spectrum_painter/spectrum_painter.py
@@ -28,6 +28,7 @@ class SpectrumPainter(object):
 
         # Generate random phase vectors for the FFT bins, this is important to prevent high peaks in the output
         # The phases won't be visible in the spectrum
+        np.seed(0)
         phases = 2*np.pi*np.random.rand(*fftall.shape)
         rffts = fftall * np.exp(1j*phases)
 

--- a/spectrum_painter/spectrum_painter.py
+++ b/spectrum_painter/spectrum_painter.py
@@ -28,7 +28,7 @@ class SpectrumPainter(object):
 
         # Generate random phase vectors for the FFT bins, this is important to prevent high peaks in the output
         # The phases won't be visible in the spectrum
-        np.seed(0)
+        np.random.seed(0)
         phases = 2*np.pi*np.random.rand(*fftall.shape)
         rffts = fftall * np.exp(1j*phases)
 


### PR DESCRIPTION
The first commit removes the numpy tostring() function deprecated in 1.19.0 (currently at 1.26.4 on PyPi). The replacement is tobytes().

The second commit adds a seed when generating random phases. This is so any image produces identical IQ data when the program is re-run. My application is in a capture the flag where having consistent IQ data is important.